### PR TITLE
Fixup UDFPS icons and animations for multi-user

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/LockIconView.java
+++ b/packages/SystemUI/src/com/android/keyguard/LockIconView.java
@@ -26,6 +26,7 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.provider.Settings;
+import android.os.UserHandle;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
@@ -201,8 +202,8 @@ public class LockIconView extends FrameLayout implements Dumpable {
     }
 
     private void addBgImageView(Context context, AttributeSet attrs) {
-        boolean customUdfpsIcon = Settings.System.getInt(
-                context.getContentResolver(), Settings.System.UDFPS_ICON, 0) != 0;
+        boolean customUdfpsIcon = Settings.System.getIntForUser(
+                context.getContentResolver(), Settings.System.UDFPS_ICON, 0, UserHandle.USER_CURRENT) != 0;
         mBgView = new ImageView(context, attrs);
         mBgView.setId(R.id.lock_icon_bg);
         mBgView.setImageDrawable(customUdfpsIcon

--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsControllerOverlay.kt
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsControllerOverlay.kt
@@ -31,6 +31,7 @@ import android.hardware.biometrics.BiometricRequestConstants.RequestReason
 import android.hardware.fingerprint.IUdfpsOverlayControllerCallback
 import android.os.Build
 import android.os.RemoteException
+import android.os.UserHandle;
 import android.provider.Settings
 import android.util.Log
 import android.util.RotationUtils
@@ -428,9 +429,9 @@ class UdfpsControllerOverlay @JvmOverloads constructor(
             REASON_ENROLL_FIND_SENSOR, REASON_ENROLL_ENROLLING -> true
             else -> false
         }
-
-        val customUdfpsIcon = Settings.System.getInt(context.contentResolver,
-            Settings.System.UDFPS_ICON, 0) != 0
+        
+        val customUdfpsIcon = Settings.System.getIntForUser(context.contentResolver, 
+            Settings.System.UDFPS_ICON, 0, UserHandle.USER_CURRENT) != 0
 
         // Use expanded overlay unless touchExploration enabled
         var rotatedBounds =

--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsFpDrawable.kt
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsFpDrawable.kt
@@ -26,6 +26,9 @@ class UdfpsFpDrawable(context: Context) : UdfpsDrawable(context) {
         if (isDisplayConfigured) {
             return
         }
-        getUdfpsDrawable().draw(canvas)
+        val udfpsDrawable = getUdfpsDrawable()
+        if (canvas != null && udfpsDrawable != null) {
+            udfpsDrawable.draw(canvas)
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsKeyguardViewLegacy.java
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsKeyguardViewLegacy.java
@@ -30,8 +30,10 @@ import android.graphics.PorterDuffColorFilter;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.provider.Settings;
+import android.os.UserHandle;
 import android.util.AttributeSet;
 import android.util.MathUtils;
+import android.util.Slog;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -135,8 +137,8 @@ public class UdfpsKeyguardViewLegacy extends UdfpsAnimationView {
     }
 
     private void updateIcon() {
-        mCustomUdfpsIcon = mPackageInstalled && (Settings.System.getInt(
-                mContext.getContentResolver(), Settings.System.UDFPS_ICON, 0) != 0);
+        mCustomUdfpsIcon = mPackageInstalled && (Settings.System.getIntForUser(
+                mContext.getContentResolver(), Settings.System.UDFPS_ICON, 0, UserHandle.USER_CURRENT) != 0);
         mBgProtection.setImageDrawable(mCustomUdfpsIcon
                 ? mFingerprintDrawable :
                 getContext().getDrawable(R.drawable.fingerprint_bg));

--- a/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsView.kt
+++ b/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsView.kt
@@ -22,6 +22,7 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.RectF
 import android.provider.Settings
+import android.os.UserHandle;
 import android.util.AttributeSet
 import android.util.Log
 import android.view.MotionEvent
@@ -89,8 +90,8 @@ class UdfpsView(
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
 
-        val customUdfpsIcon = Settings.System.getInt(context.contentResolver,
-            Settings.System.UDFPS_ICON, 0) != 0
+        val customUdfpsIcon = Settings.System.getIntForUser(context.contentResolver, 
+            Settings.System.UDFPS_ICON, 0, UserHandle.USER_CURRENT) != 0
 
         // Updates sensor rect in relation to the overlay view
         if (!customUdfpsIcon) {

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/binder/UdfpsKeyguardViewBinder.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/binder/UdfpsKeyguardViewBinder.kt
@@ -19,6 +19,7 @@ package com.android.systemui.keyguard.ui.binder
 
 import android.graphics.RectF
 import android.provider.Settings
+import android.os.UserHandle;
 import android.view.View
 import android.widget.FrameLayout
 import androidx.asynclayoutinflater.view.AsyncLayoutInflater
@@ -62,8 +63,8 @@ object UdfpsKeyguardViewBinder {
                     fingerprintViewModel,
                     backgroundViewModel,
                 )
-                val customUdfpsIcon = Settings.System.getInt(view.context.contentResolver,
-                    Settings.System.UDFPS_ICON, 0) != 0
+                val customUdfpsIcon = Settings.System.getIntForUser(view.context.contentResolver, 
+                    Settings.System.UDFPS_ICON, 0, UserHandle.USER_CURRENT) != 0
                 if (customUdfpsIcon) {
                     parent!!.addView(inflatedInternalView)
                 } else {


### PR DESCRIPTION
**Issue 1:**
In this code snippet, due to always getting the UDFPS_ICON of the default user, when switching to another user, if the system default udfps icon is used, SystemUI enters a crash loop after the first lock screen.

https://github.com/Evolution-XYZ/frameworks_base/blob/9aa3f2944129cd85bb3822a8f32226c154cb14ac/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsKeyguardViewLegacy.java#L138-L139

crash log:
https://paste.evolution-x.org/N4Cd0y

And in all the code related to UDFPS_ICON in SystemUI, they only get it for the default user, which clearly does not support multi-user.

**Solution:**
Considering that multi-user is a core feature provided by AOSP, this feature should not be broken. Therefore, I have fixed this issue in a single commit.
https://github.com/Evolution-XYZ/frameworks_base/commit/59f40f64bd8c8ece7a02ae5da304f3912c9e4a2d

**Issue 2:**
In contrast to UDFPS_ICON, this code snippet considers multi-user when getting UDFPS_ANIM_STYLE.
https://github.com/Evolution-XYZ/frameworks_base/blob/9aa3f2944129cd85bb3822a8f32226c154cb14ac/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsAnimation.java#L122-L123

But, listens udfpsAnimStyle in the constructor, causing it to listen for changes only from the default user.
https://github.com/Evolution-XYZ/frameworks_base/blob/9aa3f2944129cd85bb3822a8f32226c154cb14ac/packages/SystemUI/src/com/android/systemui/biometrics/UdfpsAnimation.java#L130-L132

When setting UDFPS animations on a non-default user, the new settings are not taking effect.

**Solution:**
I have fixed this issue in a single commit.
Add a BroadcastReceiver for ACTION_USER_SWITCHED and re-register the listener after a user switch. 
https://github.com/Evolution-XYZ/frameworks_base/commit/0141d47d36b2ed86dd2e7af2b0c18a22715f7bd3

**Testing:**
I have completed testing for the two commits, including dirty installation and fresh installation. 
I created multiple users and set different UDFPS icons (including the system default) and UDFPS animations (including disabling animations).