### PR TITLE
Vibrator: Force to return a non-zero duration

### DIFF
--- a/core/java/android/os/Vibrator.java
+++ b/core/java/android/os/Vibrator.java
@@ -690,6 +690,9 @@ public abstract class Vibrator {
         int[] durations = new int[primitiveIds.length];
         for (int i = 0; i < primitiveIds.length; i++) {
             durations[i] = info.getPrimitiveDuration(primitiveIds[i]);
+            if (durations[i] == 0) {
+                durations[i] = 1;
+            }
         }
         return durations;
     }


### PR DESCRIPTION
For some unconfigured primitiveIds, when getting their duration, force a return of 1ms. This is to avoid division by zero errors in certain apps.

In ‘Circle to Search‘, it uses primitiveId 7-9  from the Vibration HAL service. 
For devices that do not have these ids configured, when the duration is retrieved as 0, it can cause a division by zero error in Circle to Search.

This fix is to prevent ‘Circle to Search‘ from throwing that exception without breaking other functionalities or requiring modifications to the device.

After configuring primitiveIds 7-9 for the Vibration HAL service, this exception will not occur. 
But, when using ‘Circle to Search‘ by swiping the screen, there will be a continuous vibration effect. 
I understand that this is a frequently used feature for some users. 
So, this fix can disable vibration and provide power consumption optimization for devices that do not have these ids configured.
For devices that have these ids configured, they will still experience the vibration effect in ‘Circle to Search‘.